### PR TITLE
fix gs-232 "C" command output

### DIFF
--- a/IP-rotator.ino
+++ b/IP-rotator.ino
@@ -2249,6 +2249,7 @@ long RawTmp = 0;
 
   // C 67 Antenna Direction Value
   }else if(incomingByte==67){
+    Prn(OUT, 0, "+0" );
     if(Azimuth+StartAzimuth < 100){
       Prn(OUT, 0, "0" );
       if(Azimuth+StartAzimuth < 10){


### PR DESCRIPTION
Fix the output of the "C" command so it matches the Yaesu specification.  Fixes issue with PstRotatorAz not showing rotator direction.

The documentation at https://www.yaesu.com/downloadFile.cfm?FileID=820&FileCatID=155&FileName=GS232A.pdf&FileContentType=application%2Fpdf specifies the output must have the form "+0nnn".