### PR TITLE
Fix race condition causing map load failure on high latency networks

### DIFF
--- a/index.h
+++ b/index.h
@@ -121,7 +121,6 @@ const char MAIN_page[] PROGMEM = R"=====(
 	setInterval(function() { getData();}, 500); //mSeconds update rate
 	setInterval(function() { CheckOnline();}, 2000); //mSeconds update rate
 	getSet();
-	setTimeout(() => { map(); }, 1000);
 	Static();
 	StaticBot();
 	var AZtarget;
@@ -188,6 +187,7 @@ const char MAIN_page[] PROGMEM = R"=====(
 	    if (this.readyState == 4 && this.status == 200) {
 	      // document.getElementById("AntName").innerHTML = this.responseText;
 				MapUrl = this.responseText;
+				map();
 				// console.log ('MapUrl ' + MapUrl);
 	    }
 	  };


### PR DESCRIPTION
This change addresses an issue where the background map image frequently fails to load when the device is accessed over WAN or via a reverse proxy (e.g., Cloudflare).

**The Problem:**
The current implementation relies on a hardcoded `setTimeout` of 1000ms to trigger the `map()` function. If the AJAX request to `readMapUrl` takes longer than 1 second to complete (due to network latency), the `MapUrl` variable has not yet been populated. Consequently, the script attempts to load an invalid image source (often resulting in a 404 for `/0`), and the background remains blank.

**The Solution:**
This patch changes the rendering logic from time-driven to event-driven:
1. Removes the arbitrary `setTimeout`.
2. Moves the `map()` execution call inside the `onreadystatechange` callback of the `readMapUrl` request.

**Why this works:**
This ensures that the map rendering function is called *only* and *immediately* after the client has successfully received the correct image URL from the server, regardless of whether the network request takes 50ms or 5000ms.

**Disclaimer:**
This fix is based on code logic analysis to resolve the described latency issue. It has **not** been compiled or tested on physical hardware by the author of this PR. Please verify on a device.